### PR TITLE
Fix broken contact/project links and improve SEO + performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Karandeep Bhardwaj — Lead Software Engineer. 7+ years building production AI systems and cloud-native distributed platforms across financial services and supply chain. Go, Python, TypeScript · LangGraph · Amazon Bedrock · MCP · Serverless AWS." />
 <meta name="author" content="Karandeep Bhardwaj" />
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+<meta name="keywords" content="Karandeep Bhardwaj, Lead Software Engineer, AI Systems Architect, Agentic Workflows, LangGraph, Amazon Bedrock, MCP, Serverless AWS, Go, Python, TypeScript, Toronto" />
 <meta name="theme-color" content="#F2EFE9" />
 <meta name="color-scheme" content="light" />
 <link rel="canonical" href="https://karandeepbhardwaj.me/" />
@@ -20,6 +22,7 @@
 <meta property="og:title" content="Karandeep Bhardwaj — Lead Software Engineer" />
 <meta property="og:description" content="7+ years building production AI systems and cloud-native distributed platforms. Go · Python · LangGraph · Amazon Bedrock · MCP · Serverless AWS" />
 <meta property="og:image" content="https://karandeepbhardwaj.me/og-cover.png" />
+<meta property="og:image:secure_url" content="https://karandeepbhardwaj.me/og-cover.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:image:type" content="image/png" />
@@ -72,6 +75,10 @@
 </script>
 
 <title>Karandeep Bhardwaj — Lead Software Engineer</title>
+
+<!-- Speed up the deferred analytics beacon without blocking render -->
+<link rel="dns-prefetch" href="https://static.cloudflareinsights.com" />
+<link rel="preconnect" href="https://static.cloudflareinsights.com" crossorigin />
 
 <link rel="preload" href="fonts/hanken-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin />
 

--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,10 @@
   try { if (window.top !== window.self) { window.top.location = window.self.location; } } catch (e) {}
 
   var views = document.querySelectorAll('.view');
-  var tabs = document.querySelectorAll('[data-view]');
+  // Only the actual tab controls — NOT the section panels (which also carry
+  // [data-view]). Binding the click handler to a section would preventDefault()
+  // every click that bubbles up from inside it, breaking links (contact, projects).
+  var tabs = document.querySelectorAll('.nav-btn, .bb-btn');
   var nav = document.getElementById('nav');
   var indicator = document.getElementById('navIndicator');
   var valid = ['about', 'experience', 'projects', 'skills', 'education', 'contact'];

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://karandeepbhardwaj.me/</loc>
-    <lastmod>2026-06-05</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
   </url>
 </urlset>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Minimal service worker. The document is network-first (always fresh after a
 // deploy); static assets are cache-first; everything works offline once cached.
-const CACHE_NAME = 'kb-portfolio-v14';
+const CACHE_NAME = 'kb-portfolio-v15';
 const urlsToCache = [
     '/',
     '/index.html',


### PR DESCRIPTION
## Summary

Fixes the broken Contact links (LinkedIn / GitHub / X) — and the Project "View on GitHub" links, which had the same bug — and adds a round of SEO + performance improvements.

## The link bug

The links were never malformed; they had correct `href` and `target="_blank"`. The bug was in the section router (`js/app.js`): it selected tab controls with `querySelectorAll('[data-view]')`, which **also matches the six `<section>` panels** (they carry `data-view="contact"`, etc.). A click handler calling `e.preventDefault()` was then bound to each section, so every click *inside* a section bubbled up and had its default navigation cancelled — silently killing the links.

**Fix:** scope the tab handlers to `.nav-btn, .bb-btn` only. Links now navigate and open in a new tab. As a bonus, `aria-selected` is no longer incorrectly applied to `role="tabpanel"` sections (accessibility win).

## SEO / Lighthouse

- `robots` meta with `max-image-preview:large, max-snippet:-1` for richer Google snippets/image previews, plus `keywords` meta.
- `og:image:secure_url` for social scrapers.
- `dns-prefetch` + `preconnect` to the analytics origin to cut beacon latency.
- Refreshed sitemap `lastmod` + added `priority`.
- Bumped the service-worker cache (`v14 → v15`) so returning visitors receive the fixed `app.js` (served cache-first) rather than the stale broken copy.

## Verification

Tested in a real Chromium browser (Playwright):
- All three Contact links and the Project links navigate with `defaultPrevented: false` and `target="_blank"`.
- Section navigation, keyboard arrows, and the click-to-reveal email still work.
- No console/page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019D1DN69i5sh2hD76BwUp2V)_